### PR TITLE
use ppxlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ env:
   global:
   - PINS="bitstring:. ppx_bitstring:."
   jobs:
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.02 TESTS=false
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.03 TESTS=false
   - PACKAGE=ppx_bitstring OCAML_VERSION=4.04 TESTS=false
   - PACKAGE=ppx_bitstring OCAML_VERSION=4.05 TESTS=false
   - PACKAGE=ppx_bitstring OCAML_VERSION=4.06 TESTS=false

--- a/bitstring.opam
+++ b/bitstring.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/xguerin/bitstring"
 bug-reports: "https://github.com/xguerin/bitstring/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.04.1"}
   "stdlib-shims" {>= "0.1.0"}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  )
  (depends
   (dune (>= 2.5))
-  (ocaml (>= 4.02.3))
+  (ocaml (>= 4.04.1))
   (stdlib-shims (>= 0.1.0))
 ))
 
@@ -35,6 +35,6 @@
  )
  (depends
   (bitstring (>= 3.2.0))
-  (ocaml (or (and :with-test (>= 4.08.0)) (and (= :with-test false) (>= 4.02.3))))
+  (ocaml (or (and :with-test (>= 4.08.0)) (and (= :with-test false) (>= 4.04.1))))
   (ppxlib (and :build (>= 0.16.0)))
   (ounit :with-test)))

--- a/dune-project
+++ b/dune-project
@@ -36,6 +36,5 @@
  (depends
   (bitstring (>= 3.2.0))
   (ocaml (or (and :with-test (>= 4.08.0)) (and (= :with-test false) (>= 4.02.3))))
-  (ppx_tools_versioned (and :build (>= 5.0.0)))
-  (ocaml-migrate-parsetree (and :build (>= 1.0.5)))
+  (ppxlib (and :build (>= 0.16.0)))
   (ounit :with-test)))

--- a/ppx/dune
+++ b/ppx/dune
@@ -2,6 +2,5 @@
  (name ppx_bitstring)
  (public_name ppx_bitstring)
  (kind ppx_rewriter)
- (libraries str compiler-libs ppx_tools_versioned ocaml-migrate-parsetree)
- (preprocess
-  (pps ppx_tools_versioned.metaquot_410)))
+ (libraries str compiler-libs ppxlib)
+ (preprocess (pps ppxlib.metaquot)))

--- a/ppx_bitstring.opam
+++ b/ppx_bitstring.opam
@@ -16,8 +16,7 @@ depends: [
   "dune" {>= "2.5"}
   "bitstring" {>= "3.2.0"}
   "ocaml" {with-test & >= "4.08.0" | with-test = "false" & >= "4.02.3"}
-  "ppx_tools_versioned" {build & >= "5.0.0"}
-  "ocaml-migrate-parsetree" {build & >= "1.0.5"}
+  "ppxlib" {build & >= "0.16.0"}
   "ounit" {with-test}
 ]
 build: [

--- a/ppx_bitstring.opam
+++ b/ppx_bitstring.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/xguerin/bitstring/issues"
 depends: [
   "dune" {>= "2.5"}
   "bitstring" {>= "3.2.0"}
-  "ocaml" {with-test & >= "4.08.0" | with-test = "false" & >= "4.02.3"}
+  "ocaml" {with-test & >= "4.08.0" | with-test = "false" & >= "4.04.1"}
   "ppxlib" {build & >= "0.16.0"}
   "ounit" {with-test}
 ]


### PR DESCRIPTION
This is a proposal for basing the ppx extension on `ppxlib`, as `ppx_tools_versioned` [is going to be deprecated](https://discuss.ocaml.org/t/ocaml-migrate-parsetree-2-0-0/5991). This new version passes all tests performed by a `dune runtest` invocation.