### PR TITLE
Add support for FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,23 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - PINS="bitstring:. ppx_bitstring:."
+  - PACKAGE=ppx_bitstring
   jobs:
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.04 TESTS=false
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.05 TESTS=false
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.06 TESTS=false
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.07 TESTS=false
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.08
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.09
-  - PACKAGE=ppx_bitstring OCAML_VERSION=4.10
+  - OCAML_VERSION=4.04 TESTS=false
+  - OCAML_VERSION=4.05 TESTS=false
+  - OCAML_VERSION=4.06 TESTS=false
+  - OCAML_VERSION=4.07 TESTS=false
+  - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
+  - OCAML_VERSION=4.10
+  - OCAML_VERSION=4.11
 os:
   - linux
+jobs:
+  include:
+    - env: OCAML_VERSION=4.11
+      os: osx
+    - env: OCAML_VERSION=4.11
+      os: freebsd
+    - env: OCAML_VERSION=4.11
+      arch: arm64

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,8 @@
   "\| Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful.
  )
  (depends
+  (ocaml (>= 4.04.1))
   (bitstring (>= 4.0.0))
-  (ocaml (or (and :with-test (>= 4.08.0)) (and (= :with-test false) (>= 4.04.1))))
+  (ocaml (and :with-test (>= 4.08.0)))
   (ppxlib (and :build (>= 0.16.0)))
   (ounit :with-test)))

--- a/ppx_bitstring.opam
+++ b/ppx_bitstring.opam
@@ -14,8 +14,9 @@ homepage: "https://github.com/xguerin/bitstring"
 bug-reports: "https://github.com/xguerin/bitstring/issues"
 depends: [
   "dune" {>= "2.5"}
+  "ocaml" {>= "4.04.1"}
   "bitstring" {>= "4.0.0"}
-  "ocaml" {with-test & >= "4.08.0" | with-test = "false" & >= "4.04.1"}
+  "ocaml" {with-test & >= "4.08.0"}
   "ppxlib" {build & >= "0.16.0"}
   "ounit" {with-test}
 ]

--- a/src/bitstring_fastpath.c
+++ b/src/bitstring_fastpath.c
@@ -26,6 +26,8 @@
 
 #if defined(__APPLE__)
 #include <machine/endian.h>
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
The CI on opam-repository failed to build bitstring on FreeBSD. Here is a PR to fix the issue.
This might change in FreeBSD 13.0 though but this should be fine anyway. See: https://reviews.freebsd.org/D19500

This PR also adds testing for macos, freebsd and arm64 just in case.