### PR TITLE
Use :standard in dune flags stanza

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,5 +4,5 @@
  (foreign_stubs
   (language c)
   (names bitstring_fastpath)
-  (flags -I.))
+  (flags :standard -I.))
  (libraries str unix stdlib-shims))


### PR DESCRIPTION
The include flag causes compilation error on OCaml 5.4.0 and gcc (GCC) 15.2.1 20251022 (Red Hat 15.2.1-3)

Log:
```
File "src/dune", lines 1-8, characters 0-162:
1 | (library
2 |  (name bitstring)
3 |  (public_name bitstring)
4 |  (foreign_stubs
5 |   (language c)
6 |   (names bitstring_fastpath)
7 |   (flags -I.))
8 |  (libraries str unix stdlib-shims))
/usr/bin/ld: src/bitstring_fastpath.o: relocation R_X86_64_32S against
`.data' can not be used when making a shared object; recompile with
-fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```